### PR TITLE
Implement user prompt API for BaseCommand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+This repository uses Ruff for linting and pytest for tests.
+
+When modifying files:
+1. Install development dependencies with `pip install -e .[dev]`.
+2. Run `ruff check src tests` and fix any reported issues.
+3. Run `pytest -q` to ensure tests pass.
+
+Only commit changes once these checks succeed.

--- a/plugin-guide.md
+++ b/plugin-guide.md
@@ -168,6 +168,20 @@ class ValidatedCommand(BaseCommand):
         return 0
 ```
 
+### Prompting for User Input
+
+`BaseCommand` provides convenience helpers for interactive prompts so you don't
+have to call `input()` directly.
+
+```python
+class InteractiveCommand(BaseCommand):
+    def execute(self) -> int:
+        name = self.prompt("Enter your name", default="Stranger")
+        if self.prompt_confirm("Continue?", default=True):
+            self.print_success(f"Hello {name}!")
+        return 0
+```
+
 ## Creating Widgets
 
 Widgets provide visual components for terminal-based dashboard interfaces.

--- a/src/hyper_core/commands/base.py
+++ b/src/hyper_core/commands/base.py
@@ -159,6 +159,40 @@ class BaseCommand(ABC, ICommand):
         with self.show_progress(description, total) as (progress, task_id):
             yield progress, task_id
 
+    def prompt(self, message: str, default: str | None = None) -> str:
+        """Prompt the user for text input using the command console.
+
+        Args:
+            message: Prompt message shown to the user
+            default: Optional default value if the user presses Enter
+
+        Returns:
+            The user provided value or ``default`` if given and no input was
+            entered.
+        """
+
+        response = self.console.input(message + " ")
+        if response == "" and default is not None:
+            return default
+        return response
+
+    def prompt_confirm(self, message: str, default: bool = False) -> bool:
+        """Prompt the user for a yes/no confirmation.
+
+        Args:
+            message: Prompt message shown to the user
+            default: Value returned when the user just presses Enter
+
+        Returns:
+            ``True`` if the user responded with yes, ``False`` otherwise.
+        """
+
+        prompt = f"{message} [{'Y/n' if default else 'y/N'}]:"
+        response = self.prompt(prompt)
+        if response == "":
+            return default
+        return response.strip().lower().startswith("y")
+
     def print_success(self, message: str) -> None:
         """Print a success message in green."""
         self.console.print(f"[green]✓[/] {message}")

--- a/src/hyper_core/commands/base.py
+++ b/src/hyper_core/commands/base.py
@@ -159,7 +159,7 @@ class BaseCommand(ABC, ICommand):
         with self.show_progress(description, total) as (progress, task_id):
             yield progress, task_id
 
-    def prompt(self, message: str, default: str | None = None) -> str:
+    def prompt(self, message: str, default: Optional[str] = None) -> str:
         """Prompt the user for text input using the command console.
 
         Args:

--- a/src/hyper_core/commands/init.py
+++ b/src/hyper_core/commands/init.py
@@ -96,7 +96,9 @@ class InitCommand(BaseCommand):
 
     def _confirm_overwrite(self) -> bool:
         """Ask user to confirm overwriting existing .hyper directory."""
-        return self.prompt_confirm("Do you want to overwrite the existing .hyper directory?", default=False)
+        return self.prompt_confirm(
+            "Do you want to overwrite the existing .hyper directory?", default=False
+        )
 
     def _confirm_proceed(self) -> bool:
         """Ask user to confirm proceeding with initialization."""

--- a/src/hyper_core/commands/init.py
+++ b/src/hyper_core/commands/init.py
@@ -96,13 +96,11 @@ class InitCommand(BaseCommand):
 
     def _confirm_overwrite(self) -> bool:
         """Ask user to confirm overwriting existing .hyper directory."""
-        response = input("Do you want to overwrite the existing .hyper directory? [y/N]: ")
-        return response.lower().startswith("y")
+        return self.prompt_confirm("Do you want to overwrite the existing .hyper directory?", default=False)
 
     def _confirm_proceed(self) -> bool:
         """Ask user to confirm proceeding with initialization."""
-        response = input("Proceed with initialization? [Y/n]: ")
-        return not response.lower().startswith("n")
+        return self.prompt_confirm("Proceed with initialization?", default=True)
 
     def _show_initialization_plan(self, project_dir: Path) -> None:
         """Show what will be created during initialization."""

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -69,7 +69,7 @@ class TestInitCommand:
         hyper_dir.mkdir()
 
         with mock.patch("pathlib.Path.cwd", return_value=tmp_path):
-            with mock.patch("builtins.input", return_value="n"):  # User says no
+            with mock.patch.object(self.init_command, "prompt_confirm", return_value=False):
                 exit_code = self.init_command.execute(force=False)
 
                 assert exit_code == 1  # Should exit with error
@@ -81,8 +81,11 @@ class TestInitCommand:
         hyper_dir.mkdir()
 
         with mock.patch("pathlib.Path.cwd", return_value=tmp_path):
-            # Mock user input: yes to overwrite, yes to proceed
-            with mock.patch("builtins.input", side_effect=["y", "y"]):
+            with mock.patch.object(
+                self.init_command,
+                "prompt_confirm",
+                side_effect=[True, True],
+            ):
                 exit_code = self.init_command.execute(force=False)
 
                 assert exit_code == 0


### PR DESCRIPTION
## Summary
- add `prompt` and `prompt_confirm` utilities to `BaseCommand`
- refactor `InitCommand` to use the new API
- document the user prompt helpers in the plugin guide
- update tests for new confirmation method

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dfcf011c8332b1508e9b16f573b8