### PR TITLE
Fix plugin reload flag

### DIFF
--- a/src/hyper_core/plugins/loader.py
+++ b/src/hyper_core/plugins/loader.py
@@ -251,6 +251,7 @@ class PluginLoader:
         try:
             # Create module spec with proper namespacing
             module_name = f"hyper_plugins.{plugin_name}"
+            importlib.invalidate_caches()
             spec = importlib.util.spec_from_file_location(module_name, plugin_file)
 
             if not spec or not spec.loader:
@@ -292,8 +293,7 @@ class PluginLoader:
     def _register_module(self, plugin_name: str, module: Any) -> None:
         """Register the plugin module in sys.modules."""
         module_name = f"hyper_plugins.{plugin_name}"
-        if module_name not in sys.modules:
-            sys.modules[module_name] = module
+        sys.modules[module_name] = module
 
     @staticmethod
     def load_plugin_module(plugin_path: Path, plugin_name: str) -> Optional[Any]:

--- a/src/hyper_core/plugins/registry.py
+++ b/src/hyper_core/plugins/registry.py
@@ -170,11 +170,25 @@ class PluginRegistry:
         return discovered
 
     def load_plugin(self, plugin_name: str, reload: bool = False) -> bool:
-        """Load a plugin by name."""
+        """Load a plugin by name.
+
+        Args:
+            plugin_name: Name of the plugin to load.
+            reload: If ``True`` and the plugin is already loaded, unload and
+                reload it. When ``False`` the method simply returns ``True`` if
+                the plugin is already present.
+        """
         try:
-            # If plugin already exists, unload it first to ensure replacement
             if plugin_name in self._plugins:
-                logger.info(f"Plugin '{plugin_name}' already loaded, unloading for replacement")
+                if not reload:
+                    logger.info(
+                        f"Plugin '{plugin_name}' already loaded; skipping reload"
+                    )
+                    return True
+
+                logger.info(
+                    f"Plugin '{plugin_name}' already loaded, unloading for replacement"
+                )
                 self.unload_plugin(plugin_name)
 
             # Trigger lifecycle hook

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -372,6 +372,49 @@ class {plugin_name.title().replace("_", "")}Command(BaseCommand):
         finally:
             os.chdir(original_cwd)
 
+    def test_load_plugin_skip_reload_flag(self):
+        """Ensure load_plugin respects the reload flag."""
+        project_root = self.create_temp_dir()
+        hyper_dir = project_root / ".hyper"
+        plugins_dir = hyper_dir / "plugins"
+        plugins_dir.mkdir(parents=True)
+
+        plugin_dir = self.create_test_plugin(plugins_dir, "flag_test")
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(project_root)
+            reset_config()
+
+            registry = PluginRegistry()
+            registry.initialize()
+
+            # Initial load
+            assert registry.load_plugin("flag_test") is True
+            mod = registry.plugins["flag_test"]["module"]
+            assert getattr(mod, "PLUGIN_VERSION", None) == "1.0.0"
+
+            # Modify plugin version
+            plugin_file = plugin_dir / "plugin.py"
+            plugin_file.write_text(
+                plugin_file.read_text().replace("1.0.0", "2.0.0")
+            )
+            new_time = os.path.getmtime(plugin_file) + 2
+            os.utime(plugin_file, (new_time, new_time))
+
+            # Reload with flag=False - should skip reload
+            assert registry.load_plugin("flag_test", reload=False) is True
+            mod = registry.plugins["flag_test"]["module"]
+            assert getattr(mod, "PLUGIN_VERSION", None) == "1.0.0"
+
+            # Reload with flag=True - should update
+            assert registry.load_plugin("flag_test", reload=True) is True
+            mod = registry.plugins["flag_test"]["module"]
+            assert getattr(mod, "PLUGIN_VERSION", None) == "2.0.0"
+
+        finally:
+            os.chdir(original_cwd)
+
 
 class TestPluginLoadingErrorHandling:
     """Test error handling in plugin loading."""


### PR DESCRIPTION
## Summary
- allow skipping reload in `load_plugin`
- always insert plugin module into `sys.modules` and invalidate caches before loading
- add unit test for skip reload behavior

## Testing
- `ruff check src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845df5fd3208332b4657b40052cbefd